### PR TITLE
Update to latest serial library.

### DIFF
--- a/dmx.go
+++ b/dmx.go
@@ -11,7 +11,7 @@ package dmx
 
 import (
 	"fmt"
-	"github.com/tarm/goserial"
+	"github.com/tarm/serial"
 	"io"
 	"log"
 )
@@ -19,7 +19,7 @@ import (
 const (
 	START_VAL       = 0x7E
 	END_VAL         = 0xE7
-	BAUD            = 57600
+	BAUD            = 115200
 	TIMEOUT         = 1
 	DEV             = "/dev/ttyUSB0"
 	FRAME_SIZE      = 511


### PR DESCRIPTION
It looks like `github.com/tarm/serial` has supplanted `github.com/tarm/goserial`. Also updated baud -- not sure if that would be an issue. I can remove the baud change if needed. In general the new serial lib seems to improve timing resolution.
